### PR TITLE
COMP: bracket all changes with conditionals for ITK4

### DIFF
--- a/Applications/DemonsRegistration.cxx
+++ b/Applications/DemonsRegistration.cxx
@@ -1,4 +1,4 @@
- /**
+/**
  * This is a small tool that shows how to use the diffeomorphic demons algorithm.
  * The user can choose if diffeomorphic, additive or compositive demons should be used.
  * The user can also choose the type of demons forces, or other parameters;

--- a/Applications/ImageCompare.cxx
+++ b/Applications/ImageCompare.cxx
@@ -176,6 +176,9 @@ int RegressionTestImage(const char *testImageFilename, const char *baselineImage
     region.SetSize(size);
 
     ExtractType::Pointer extract = ExtractType::New();
+#if (ITK_VERSION_MAJOR > 3)
+    extract->SetDirectionCollapseToIdentity();
+#endif
     extract->SetInput(rescale->GetOutput() );
     extract->SetExtractionRegion(region);
 

--- a/Code/itkLogDomainDeformableRegistrationFilter.h
+++ b/Code/itkLogDomainDeformableRegistrationFilter.h
@@ -130,8 +130,11 @@ public:
   /** Set initial velocity field. */
   void SetInitialVelocityField( VelocityFieldType * ptr )
   {
-    // this->SetInput( ptr );
+#if (ITK_VERSION_MAJOR < 4)
+    this->SetInput( ptr );
+#else
     this->SetNthInput( 2, ptr );
+#endif
   }
 
   /** Get output velocity field. */

--- a/Code/itkLogDomainDeformableRegistrationFilter.hxx
+++ b/Code/itkLogDomainDeformableRegistrationFilter.hxx
@@ -55,7 +55,11 @@ LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::SetFixedImage(
   const FixedImageType * ptr )
 {
+#if (ITK_VERSION_MAJOR < 4)
+  this->ProcessObject::SetNthInput( 1, const_cast<FixedImageType *>( ptr ) );
+#else
   this->ProcessObject::SetNthInput( 0, const_cast<FixedImageType *>( ptr ) );
+#endif
 }
 
 // Get the fixed image.
@@ -66,7 +70,11 @@ const typename LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, 
 ::GetFixedImage() const
   {
   return dynamic_cast<const FixedImageType *>
+#if (ITK_VERSION_MAJOR < 4)
+         ( this->ProcessObject::GetInput( 1 ) );
+#else
          ( this->ProcessObject::GetInput( 0 ) );
+#endif
   }
 
 // Set the moving image.
@@ -76,7 +84,11 @@ LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::SetMovingImage(
   const MovingImageType * ptr )
 {
+#if (ITK_VERSION_MAJOR < 4)
+  this->ProcessObject::SetNthInput( 2, const_cast<MovingImageType *>( ptr ) );
+#else
   this->ProcessObject::SetNthInput( 1, const_cast<MovingImageType *>( ptr ) );
+#endif
 }
 
 // Get the moving image.
@@ -87,7 +99,11 @@ const typename LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, 
 ::GetMovingImage() const
   {
   return dynamic_cast<const MovingImageType *>
+#if (ITK_VERSION_MAJOR < 4)
+         ( this->ProcessObject::GetInput( 2 ) );
+#else
          ( this->ProcessObject::GetInput( 1 ) );
+#endif
   }
 
 template <class TFixedImage, class TMovingImage, class TField>
@@ -243,7 +259,11 @@ LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::CopyInputToOutput()
 {
 
+#if (ITK_VERSION_MAJOR < 4)
+  typename Superclass::InputImageType::ConstPointer  inputPtr  = this->GetInput();
+#else
   typename Superclass::InputImageType::ConstPointer  inputPtr  = this->GetInput(2);
+#endif
 
   if( inputPtr )
     {
@@ -277,7 +297,11 @@ LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
   // std::cout<<"LogDomainDeformableRegistrationFilter::GenerateOutputInformation"<<std::endl;
   typename DataObject::Pointer output;
 
+#if (ITK_VERSION_MAJOR < 4)
+  if( this->GetInput(0) )
+#else
   if( this->GetInput(2) )
+#endif
     {
     // Initial velocity field is set.
     // Copy information from initial field.
@@ -321,8 +345,13 @@ LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 
   // just propagate up the output requested region for
   // the fixed image and initial velocity field.
+#if (ITK_VERSION_MAJOR < 4)
+  VelocityFieldPointer inputPtr =
+    const_cast<VelocityFieldType *>( this->GetInput() );
+#else
   VelocityFieldPointer inputPtr =
     const_cast<VelocityFieldType *>( this->GetInput(2) );
+#endif
   VelocityFieldPointer outputPtr = this->GetOutput();
   FixedImagePointer    fixedPtr =
     const_cast<FixedImageType *>( this->GetFixedImage() );

--- a/Code/itkMultiResolutionLogDomainDeformableRegistration.h
+++ b/Code/itkMultiResolutionLogDomainDeformableRegistration.h
@@ -161,8 +161,11 @@ public:
    *  images characteristics at the coarsest level of the pyramid. */
   virtual void SetArbitraryInitialVelocityField( VelocityFieldType * ptr )
   {
-    // this->SetInput( ptr );
+#if (ITK_VERSION_MAJOR < 4)
+    this->SetInput( ptr );
+#else
     this->SetNthInput(2, ptr);
+#endif
   }
 
   /** Get output velocity field. */

--- a/Code/itkMultiResolutionLogDomainDeformableRegistration.hxx
+++ b/Code/itkMultiResolutionLogDomainDeformableRegistration.hxx
@@ -68,7 +68,11 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField
 ::SetMovingImage(
   const MovingImageType * ptr )
 {
+#if (ITK_VERSION_MAJOR < 4)
+  this->ProcessObject::SetNthInput( 2, const_cast<MovingImageType *>( ptr ) );
+#else
   this->ProcessObject::SetNthInput( 1, const_cast<MovingImageType *>( ptr ) );
+#endif
 }
 
 // Get the moving image image.
@@ -79,7 +83,11 @@ const typename MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovi
 ::GetMovingImage(void) const
   {
   return dynamic_cast<const MovingImageType *>
+#if (ITK_VERSION_MAJOR < 4)
+         ( this->ProcessObject::GetInput( 2 ) );
+#else
          ( this->ProcessObject::GetInput( 1 ) );
+#endif
   }
 
 // Set the fixed image.
@@ -89,7 +97,11 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField
 ::SetFixedImage(
   const FixedImageType * ptr )
 {
+#if (ITK_VERSION_MAJOR < 4)
+  this->ProcessObject::SetNthInput( 1, const_cast<FixedImageType *>( ptr ) );
+#else
   this->ProcessObject::SetNthInput( 0, const_cast<FixedImageType *>( ptr ) );
+#endif
 }
 
 // Get the fixed image.
@@ -100,7 +112,11 @@ const typename MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovi
 ::GetFixedImage(void) const
   {
   return dynamic_cast<const FixedImageType *>
+#if (ITK_VERSION_MAJOR < 4)
+         ( this->ProcessObject::GetInput( 1 ) );
+#else
          ( this->ProcessObject::GetInput( 0 ) );
+#endif
   }
 
 template <class TFixedImage, class TMovingImage, class TField, class TRealType>
@@ -219,7 +235,11 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField
     itkExceptionMacro( << "Registration filter not set" );
     }
 
+#if (ITK_VERSION_MAJOR < 4)
+  if( this->m_InitialVelocityField && this->GetInput(0) )
+#else
   if( this->m_InitialVelocityField && this->GetInput(2) )
+#endif
     {
     itkExceptionMacro( << "Only one initial velocity can be given. "
                        << "SetInitialVelocityField should not be used in "
@@ -247,8 +267,11 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField
   VelocityFieldPointer tempField = NULL;
 
   VelocityFieldPointer inputPtr =
+#if (ITK_VERSION_MAJOR < 4)
+    const_cast<VelocityFieldType *>( this->GetInput(0) );
+#else
     const_cast<VelocityFieldType *>( this->GetInput(2) );
-
+#endif
   if( this->m_InitialVelocityField )
     {
     tempField = this->m_InitialVelocityField;
@@ -462,7 +485,11 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField
 
   typename DataObject::Pointer output;
 
+#if (ITK_VERSION_MAJOR < 4)
+  if( this->GetInput(0) )
+#else
   if( this->GetInput(2) )
+#endif
     {
     // Initial velocity field is set.
     // Copy information from initial field.
@@ -507,7 +534,11 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField
   // just propagate up the output requested region for
   // the fixed image and initial velocity field.
   VelocityFieldPointer inputPtr =
+#if (ITK_VERSION_MAJOR < 4)
+    const_cast<VelocityFieldType *>( this->GetInput() );
+#else
     const_cast<VelocityFieldType *>( this->GetInput(2) );
+#endif
   VelocityFieldPointer outputPtr = this->GetOutput();
   FixedImagePointer    fixedPtr =
     const_cast<FixedImageType *>( this->GetFixedImage() );

--- a/Testing/itkDisplacementFieldCompositionFilterTest.cxx
+++ b/Testing/itkDisplacementFieldCompositionFilterTest.cxx
@@ -13,6 +13,7 @@
 #include "itkStreamingImageFilter.h"
 #include "vnl/vnl_math.h"
 #include "itkCommand.h"
+#include "itkMultiThreader.h"
 
 // The following three classes are used to support callbacks
 // on the filter in the pipeline that follows later
@@ -32,6 +33,7 @@ public:
 
 int main(int, char * [] )
 {
+  itk::MultiThreader::SetGlobalMaximumNumberOfThreads(1);
   const unsigned int ImageDimension = 2;
 
   typedef itk::Vector<float, ImageDimension>     VectorType;


### PR DESCRIPTION
I verified that if you use GCC to compile, then these changes do not break the 3.2 build.  The results are the same.
