### PR TITLE
COMP: Build tuning

### DIFF
--- a/SuperBuild/CMakeLists.txt
+++ b/SuperBuild/CMakeLists.txt
@@ -36,3 +36,15 @@ ExternalProject_add(LogSymmetricDemons
   -DITK_DIR:PATH=${ITK_DIR}
   DEPENDS ITKv4
 )
+set(stampDir ${CMAKE_CURRENT_BUILD_DIR}/LogSymmetricDemons-prefix/src/LogSymmetricDemons-stamp)
+set(stampFiles
+#  ${stampDir}/LogSymmetricDemons-configure
+  ${stampDir}/LogSymmetricDemons-build
+)
+
+ExternalProject_Add_Step(LogSymmetricDemons forcebuild
+    COMMAND ${CMAKE_COMMAND} -E remove ${stampFiles}
+    DEPENDEES configure
+    DEPENDERS build
+    ALWAYS 1
+  )

--- a/SuperBuild/LogSymmetricDemons.nightly.sh
+++ b/SuperBuild/LogSymmetricDemons.nightly.sh
@@ -37,6 +37,9 @@ CFLAGS="${CFLAGS:-}"
 LDFLAGS="${LDFLAGS:-}"
 CCOverride=""
 CXXOverride=""
+coverage=""
+valgrind=""
+experimental=""
 
 while [ $# -gt 0 ]
 do
@@ -46,6 +49,8 @@ do
             coverage=1 ;;
         valgrind)
             doValgrind=1 ;;
+        [Ee]xperimental)
+            experimental=1 ;;
         CC=*)
           echo Override C Compiler ; CCOverride=`echo $1 | sed -e 's/^CC=//'` ;;
         CXX=*)
@@ -168,8 +173,8 @@ do
     make -j ${NPROCS}
     cd ${package}-build
     make clean
-    if [ "$doValgrind" != "1" ] ; then
-        if [[ $scriptname =~ '.*nightly.sh' ]] ; then
+    if [ "$doValGrind" != "1" -o "$BUILD_TYPE}" = "Release" ] ; then
+        if [[ $scriptname =~ '.*nightly.sh' ]] && [[ "${experimental}" != "1" ]] ; then
 	    ctest -j ${NPROCS} -D Nightly
             if [ "$coverage" = "1" ] ; then
                 ctest -D NightlyCoverage
@@ -180,11 +185,11 @@ do
                 ctest -D ExperimentalCoverage
             fi
         fi
-    else
-        if [[ $scriptname =~ '.*nightly.sh' ]] ; then
-	    ctest -j ${NPROCS} -D NightlyMemCheck
+    else # VALGRIND BUILD
+        if [[ $scriptname =~ '.*nightly.sh' ]] && [[ "${experimental}" != "1" ]] ; then
+	    ctest -j ${NPROCS} -D NightlyMemoryCheck
         else
-	    ctest -j ${NPROCS} -D ExperimentalMemCheck
+	    ctest -j ${NPROCS} -D ExperimentalMemoryCheck
         fi
     fi
     cd ..

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -11,6 +11,11 @@ SD_UNIT_TEST(itkSymmetricLogDomainDemonsRegistrationFilterTest2.cxx EXTLIBS ${Li
 SD_UNIT_TEST(itkTransformToVelocityFieldSourceTest.cxx EXTLIBS ${Libraries})
 SD_UNIT_TEST(itkDisplacementToVelocityFieldLogFilterTest.cxx EXTLIBS ${Libraries})
 
+set_test_properties( itkLogDomainDemonsRegistrationFilterTest
+  itkLogDomainDemonsRegistrationFilterTest2
+  PROPERTIES TIMEOUT 6000 )
+
+
 if(MATLAB_FOUND)
   include_directories(${MATLAB_INCLUDE_DIR})
   SD_UNIT_TEST(vnl_sd_matrix_tools_test.cxx EXTLIBS ${Libraries} MATLAB_ENG MATLAB_MX)


### PR DESCRIPTION
Lengthened timeout for long test. Force re-build of LSD subproject
changed name of nightly script.
add experimental flag for script, don't depend on changing script
name to run experiemental.
